### PR TITLE
Add SenderInterface and Subject arguments to address method

### DIFF
--- a/DoctrineMigration.php
+++ b/DoctrineMigration.php
@@ -18,7 +18,7 @@ final class DoctrineMigration extends AbstractMigration
                 response_payload JSON DEFAULT NULL COMMENT '(DC2Type:json_array)', 
                 delivered_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', 
                 INDEX IDX_E6A08DE7B2E4466F (vars_id), 
-                INDEX campaign_idx (campaign), 
+                INDEX chunk_campaign_idx (campaign), 
                 PRIMARY KEY(id)
             ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB
 SQL
@@ -43,8 +43,7 @@ SQL
                 name VARCHAR(255) DEFAULT NULL, 
                 email VARCHAR(255) NOT NULL, 
                 canonical_email VARCHAR(255) NOT NULL, 
-                UNIQUE INDEX UNIQ_46D4451BFD10FFAF (canonical_email), 
-                INDEX email_idx (canonical_email), 
+                UNIQUE INDEX unique_email_name (canonical_email, name), 
                 PRIMARY KEY(id)
             ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB
 SQL
@@ -54,39 +53,42 @@ SQL
             CREATE TABLE mailer_mail_vars (
                 id INT UNSIGNED AUTO_INCREMENT NOT NULL, 
                 reply_to_id INT UNSIGNED DEFAULT NULL, 
+                sender_name VARCHAR(255) DEFAULT NULL, 
+                sender_email VARCHAR(255) DEFAULT NULL,
                 app VARCHAR(255) NOT NULL, 
                 type VARCHAR(255) NOT NULL, 
                 template_name VARCHAR(255) NOT NULL, 
                 template_vars JSON NOT NULL COMMENT '(DC2Type:json_array)', 
                 campaign CHAR(36) DEFAULT NULL COMMENT '(DC2Type:uuid)', 
                 created_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', 
+                subject VARCHAR(255) DEFAULT NULL, 
                 UNIQUE INDEX UNIQ_766519DD1F1512DD (campaign), 
                 INDEX IDX_766519DDFFDF7169 (reply_to_id), 
                 INDEX app_idx (app), 
                 INDEX type_idx (type), 
-                INDEX campaign_idx (campaign), 
+                INDEX mail_campaign_idx (campaign), 
                 PRIMARY KEY(id)
             ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB
 SQL
         );
 
         $this->addSql(<<<SQL
-            CREATE TABLE mails_cc (
+            CREATE TABLE mailer_mails_cc (
                 mail_vars_id INT UNSIGNED NOT NULL, 
                 address_id INT UNSIGNED NOT NULL, 
-                INDEX IDX_F43587F56859C700 (mail_vars_id), 
-                INDEX IDX_F43587F5F5B7AF75 (address_id), 
+                INDEX IDX_33CC128C6859C700 (mail_vars_id), 
+                INDEX IDX_33CC128CF5B7AF75 (address_id), 
                 PRIMARY KEY(mail_vars_id, address_id)
             ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB
 SQL
         );
 
         $this->addSql(<<<SQL
-            CREATE TABLE mails_bcc (
+            CREATE TABLE mailer_mails_bcc (
                 mail_vars_id INT UNSIGNED NOT NULL, 
                 address_id INT UNSIGNED NOT NULL, 
-                INDEX IDX_CA58864C6859C700 (mail_vars_id), 
-                INDEX IDX_CA58864CF5B7AF75 (address_id), 
+                INDEX IDX_E346B6416859C700 (mail_vars_id), 
+                INDEX IDX_E346B641F5B7AF75 (address_id), 
                 PRIMARY KEY(mail_vars_id, address_id)
             ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB
 SQL
@@ -96,10 +98,10 @@ SQL
         $this->addSql('ALTER TABLE mailer_recipient_vars ADD CONSTRAINT FK_5BC905CEF5B7AF75 FOREIGN KEY (address_id) REFERENCES mailer_addresses (id)');
         $this->addSql('ALTER TABLE mailer_recipient_vars ADD CONSTRAINT FK_5BC905CE96BD5259 FOREIGN KEY (mail_request_id) REFERENCES mailer_mail_requests (id)');
         $this->addSql('ALTER TABLE mailer_mail_vars ADD CONSTRAINT FK_766519DDFFDF7169 FOREIGN KEY (reply_to_id) REFERENCES mailer_addresses (id)');
-        $this->addSql('ALTER TABLE mails_cc ADD CONSTRAINT FK_F43587F56859C700 FOREIGN KEY (mail_vars_id) REFERENCES mailer_mail_vars (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE mails_cc ADD CONSTRAINT FK_F43587F5F5B7AF75 FOREIGN KEY (address_id) REFERENCES mailer_addresses (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE mails_bcc ADD CONSTRAINT FK_CA58864C6859C700 FOREIGN KEY (mail_vars_id) REFERENCES mailer_mail_vars (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE mails_bcc ADD CONSTRAINT FK_CA58864CF5B7AF75 FOREIGN KEY (address_id) REFERENCES mailer_addresses (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE mailer_mails_cc ADD CONSTRAINT FK_33CC128C6859C700 FOREIGN KEY (mail_vars_id) REFERENCES mailer_mail_vars (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE mailer_mails_cc ADD CONSTRAINT FK_33CC128CF5B7AF75 FOREIGN KEY (address_id) REFERENCES mailer_addresses (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE mailer_mails_bcc ADD CONSTRAINT FK_E346B6416859C700 FOREIGN KEY (mail_vars_id) REFERENCES mailer_mail_vars (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE mailer_mails_bcc ADD CONSTRAINT FK_E346B641F5B7AF75 FOREIGN KEY (address_id) REFERENCES mailer_addresses (id) ON DELETE CASCADE');
     }
 
     public function down(Schema $schema): void
@@ -107,16 +109,16 @@ SQL
         $this->addSql('ALTER TABLE mailer_recipient_vars DROP FOREIGN KEY FK_5BC905CE96BD5259');
         $this->addSql('ALTER TABLE mailer_recipient_vars DROP FOREIGN KEY FK_5BC905CEF5B7AF75');
         $this->addSql('ALTER TABLE mailer_mail_vars DROP FOREIGN KEY FK_766519DDFFDF7169');
-        $this->addSql('ALTER TABLE mails_cc DROP FOREIGN KEY FK_F43587F5F5B7AF75');
-        $this->addSql('ALTER TABLE mails_bcc DROP FOREIGN KEY FK_CA58864CF5B7AF75');
+        $this->addSql('ALTER TABLE mailer_mails_cc DROP FOREIGN KEY FK_33CC128CF5B7AF75');
+        $this->addSql('ALTER TABLE mailer_mails_bcc DROP FOREIGN KEY FK_E346B641F5B7AF75');
         $this->addSql('ALTER TABLE mailer_mail_requests DROP FOREIGN KEY FK_E6A08DE7B2E4466F');
-        $this->addSql('ALTER TABLE mails_cc DROP FOREIGN KEY FK_F43587F56859C700');
-        $this->addSql('ALTER TABLE mails_bcc DROP FOREIGN KEY FK_CA58864C6859C700');
+        $this->addSql('ALTER TABLE mailer_mails_cc DROP FOREIGN KEY FK_33CC128C6859C700');
+        $this->addSql('ALTER TABLE mailer_mails_bcc DROP FOREIGN KEY FK_E346B6416859C700');
         $this->addSql('DROP TABLE mailer_mail_requests');
         $this->addSql('DROP TABLE mailer_recipient_vars');
         $this->addSql('DROP TABLE mailer_addresses');
         $this->addSql('DROP TABLE mailer_mail_vars');
-        $this->addSql('DROP TABLE mails_cc');
-        $this->addSql('DROP TABLE mails_bcc');
+        $this->addSql('DROP TABLE mailer_mails_cc');
+        $this->addSql('DROP TABLE mailer_mails_bcc');
     }
 }

--- a/behat/Context/MailContext.php
+++ b/behat/Context/MailContext.php
@@ -2,8 +2,10 @@
 
 namespace EnMarche\MailerBundle\Behat\Context;
 
+use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Behat\Symfony2Extension\Context\KernelDictionary;
+use Coduo\PHPMatcher\Factory\SimpleFactory;
 use EnMarche\MailerBundle\Mail\MailInterface;
 use EnMarche\MailerBundle\Test\DebugMailPost;
 use EnMarche\MailerBundle\MailPost\MailPostInterface;
@@ -12,13 +14,16 @@ class MailContext extends RawMinkContext
 {
     use KernelDictionary;
 
+    /** @var DebugMailPost */
+    private $mailPost;
+
     /**
      * @Given I should have :number email(s)( for class :mailClass)?( sent with :mailPostName)?
      */
-    public function iShouldHaveMessages(int $number, string $mailClass = null, string $mailPostName = null)
+    public function iShouldHaveMessages(int $number, string $mailClass = null, string $mailPostName = null): void
     {
         $mailPost = $this->getMailPost($mailPostName);
-        $count = $mailClass ? $mailPost->getMailsCount() : $mailPost->getMailsCountForClass($mailClass);
+        $count = $mailClass ? $mailPost->countMails() : $mailPost->countMailsForClass($mailClass);
 
         if ($number !== $count) {
             throw new \RuntimeException(sprintf('Found %d email(s) instead of %d.', $count, $number));
@@ -26,16 +31,18 @@ class MailContext extends RawMinkContext
     }
 
     /**
-     * @Given I should have 1 email :mailClass( sent with :mailPostName) for :recipient with vars:
+     * @Given I should have 1 email :mailClass for :recipient with vars:
      */
-    public function iShouldHaveEmailForWithPayload(string $maiClass, string $recipient, array $vars, string $mailPostName = null)
+    public function iShouldHaveEmailForWithPayload(string $maiClass, string $recipient, TableNode $vars, string $mailPostName = null): void
     {
-        $mail = null;
         $mailPost = $this->getMailPost($mailPostName);
 
-        if (1 !== $mailPost->getMailsCountForClass($maiClass)) {
-            throw new \RuntimeException(sprintf('I found %s email(s) instead of 1', $mailPost->getMailsCount($maiClass)));
+        if (1 !== $count = $mailPost->countMailsForClass($maiClass)) {
+            throw new \RuntimeException(sprintf('I found %s email(s) instead of 1', $count));
         }
+
+        $simpleFactory = new SimpleFactory();
+        $matcher = $simpleFactory->createMatcher();
 
         foreach ($mailPost->getMailsForClass($maiClass) as $mail) {
             if (1 !== \count($recipients = $mail->getToRecipients())) {
@@ -44,20 +51,18 @@ class MailContext extends RawMinkContext
             if ($recipient !== $email = $recipients[0]->getEmail()) {
                 throw new \RuntimeException(\sprintf('Expected recipient "%s", but got "%s".', $recipient, $email));
             }
-            if ($vars !== $actual = \array_merge($mail->getTemplateVars(), $recipients[0]->getTemplateVars())) {
+            if (!$matcher->match($actual = \array_merge($mail->getTemplateVars(), $recipients[0]->getTemplateVars()), $vars->getRowsHash())) {
                 throw new \RuntimeException(\sprintf('Failed expecting vars, got "%s".', \var_export($actual, true)));
             }
         }
     }
 
     /**
-     * @When I click on the email link :templateVars (sent with :mailPostName)?
+     * @When I click on the link :templateVars of the last email
      */
-    public function iClickOnTheEmailLink($templateVars, $mailPostName = null)
+    public function iClickOnTheEmailLink($templateVars, $mailPostName = null): void
     {
-        $mailPost = $this->getMailPost($mailPostName);
-
-        $lastMail = $mailPost->getLastSentMail();
+        $lastMail = $this->getMailPost($mailPostName)->getLastSentMail();
 
         if (!$lastMail instanceof MailInterface) {
             throw new \RuntimeException(\sprintf('No email was previously sent with mail post "%s".', $mailPostName));
@@ -82,14 +87,26 @@ class MailContext extends RawMinkContext
         $this->visitPath($link);
     }
 
+    /**
+     * @AfterScenario
+     */
+    public function clearMails(): void
+    {
+        if ($this->mailPost) {
+            $this->mailPost->clearMails();
+        }
+    }
+
     private function getMailPost(string $name = null): DebugMailPost
     {
-        $mailPost = $this->getContainer()->get($name ? "en_marche_mailer.mail_post.$name" : MailPostInterface::class);
+        if (!$this->mailPost) {
+            $this->mailPost = $this->getContainer()->get($name ? "en_marche_mailer.mail_post.$name" : MailPostInterface::class);
 
-        if (!$mailPost instanceof DebugMailPost) {
-            throw new \LogicException(\sprintf('Expected an instance of "%s", but got "%s". Are you running in test environment? Otherwise you need to explicitly load the bundle config file.', DebugMailPost::class, \get_class($mailPost)));
+            if (!$this->mailPost instanceof DebugMailPost) {
+                throw new \LogicException(\sprintf('Expected an instance of "%s", but got "%s". Are you running in test environment? Otherwise you need to explicitly load the bundle config file.', DebugMailPost::class, \get_class($mailPost)));
+            }
         }
 
-        return $mailPost;
+        return $this->mailPost;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "symfony/http-kernel": "~3.4 || ^4.0"
     },
     "require-dev": {
+        "coduo/php-matcher": "^3.1",
         "doctrine/doctrine-bundle": "^1.9",
         "guzzlehttp/guzzle": "^6.3",
         "php-amqplib/rabbitmq-bundle": "^1.14",

--- a/src/Client/MailRequestInterface.php
+++ b/src/Client/MailRequestInterface.php
@@ -16,6 +16,10 @@ interface MailRequestInterface
 
     public function getReplyTo(): ?Address;
 
+    public function getSenderName(): ?string;
+
+    public function getSenderEmail(): ?string;
+
     public function getTemplateName(): string;
 
     /**
@@ -58,4 +62,6 @@ interface MailRequestInterface
     public function deliver(array $responsePayload): void;
 
     public function getDeliveredAt(): ?\DateTimeImmutable;
+
+    public function getSubject(): ?string;
 }

--- a/src/Client/PayloadFactory/AbstractPayloadFactory.php
+++ b/src/Client/PayloadFactory/AbstractPayloadFactory.php
@@ -2,6 +2,7 @@
 
 namespace EnMarche\MailerBundle\Client\PayloadFactory;
 
+use EnMarche\MailerBundle\Client\MailRequestInterface;
 use EnMarche\MailerBundle\Client\PayloadFactoryInterface;
 
 abstract class AbstractPayloadFactory implements PayloadFactoryInterface
@@ -15,13 +16,21 @@ abstract class AbstractPayloadFactory implements PayloadFactoryInterface
         $this->senderName = $senderName;
     }
 
-    public function getSenderEmail(): ?string
+    public function getSenderEmail(MailRequestInterface $mailRequest): ?string
     {
+        if ($senderEmail = $mailRequest->getSenderEmail()) {
+            return $senderEmail;
+        }
+
         return $this->senderEmail;
     }
 
-    public function getSenderName(): ?string
+    public function getSenderName(MailRequestInterface $mailRequest): ?string
     {
+        if ($senderName = $mailRequest->getSenderName()) {
+            return $senderName;
+        }
+
         return $this->senderName;
     }
 }

--- a/src/Client/PayloadFactory/MailjetPayloadFactory.php
+++ b/src/Client/PayloadFactory/MailjetPayloadFactory.php
@@ -33,12 +33,16 @@ class MailjetPayloadFactory extends AbstractPayloadFactory
             $payload['Headers']['Reply-To'] = $this->formatAddress($replyTo);
         }
 
-        if ($this->getSenderEmail()) {
-            $payload['FromEmail'] = $this->getSenderEmail();
+        if ($subject = $mailRequest->getSubject()) {
+            $payload['Subject'] = $subject;
         }
 
-        if ($this->getSenderName()) {
-            $payload['FromName'] = $this->getSenderName();
+        if ($senderEmail = $this->getSenderEmail($mailRequest)) {
+            $payload['FromEmail'] = $senderEmail;
+        }
+
+        if ($senderName = $this->getSenderName($mailRequest)) {
+            $payload['FromName'] = $senderName;
         }
 
         if ($mailRequest->getCampaign()) {
@@ -88,16 +92,18 @@ class MailjetPayloadFactory extends AbstractPayloadFactory
 
     private function createCampaignPayload(MailRequestInterface $mailRequest, array $payload): array
     {
-        $templateVars = $mailRequest->getTemplateVars();
+        if ($templateVars = $mailRequest->getTemplateVars()) {
+            $payload['Vars'] = $templateVars;
+        }
 
         foreach ($mailRequest->getRecipientVars() as $recipient) {
-            $payload['Recipients'][] = $this->createRecipient($recipient, $templateVars);
+            $payload['Recipients'][] = $this->createRecipient($recipient);
         }
 
         return $payload;
     }
 
-    private function createRecipient(RecipientVars $recipientVars, array $templateVars): array
+    private function createRecipient(RecipientVars $recipientVars): array
     {
         $address = $recipientVars->getAddress();
 
@@ -109,7 +115,7 @@ class MailjetPayloadFactory extends AbstractPayloadFactory
             $recipient['Name'] = $name;
         }
 
-        if ($vars = \array_merge($templateVars, $recipientVars->getTemplateVars())) {
+        if ($vars = $recipientVars->getTemplateVars()) {
             $recipient['Vars'] = $vars;
         }
 

--- a/src/Client/PayloadFactoryInterface.php
+++ b/src/Client/PayloadFactoryInterface.php
@@ -8,9 +8,9 @@ use Psr\Http\Message\ResponseInterface;
 
 interface PayloadFactoryInterface
 {
-    public function getSenderEmail(): ?string;
+    public function getSenderEmail(MailRequestInterface $mailRequest): ?string;
 
-    public function getSenderName(): ?string;
+    public function getSenderName(MailRequestInterface $mailRequest): ?string;
 
     /**
      * @throws InvalidMailRequestException

--- a/src/DependencyInjection/EnMarcheMailerExtension.php
+++ b/src/DependencyInjection/EnMarcheMailerExtension.php
@@ -343,6 +343,7 @@ class EnMarcheMailerExtension extends Extension implements PrependExtensionInter
                     ->addArgument($mailPostName)
                     ->setPublic(true)
                 ;
+                $container->getAlias(MailPostInterface::class)->setPublic(true);
                 if ($isDefault) {
                     // Need to set the class if the default definition already exists
                     $defaultMailPost->setClass(DebugMailPost::class);

--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -8,8 +8,8 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity(repositoryClass="EnMarche\MailerBundle\Repository\AddressRepository")
  * @ORM\Table(
  *     name="mailer_addresses",
- *     indexes={
- *         @ORM\Index(name="unique_address_idx", columns={"canonical_email", "name"})
+ *     uniqueConstraints={
+ *         @ORM\UniqueConstraint(name="unique_email_name", columns={"canonical_email", "name"})
  *     }
  * )
  */
@@ -41,7 +41,7 @@ class Address
     /**
      * @var string
      *
-     * @ORM\Column(unique=true)
+     * @ORM\Column
      */
     private $canonicalEmail;
 

--- a/src/Entity/MailRequest.php
+++ b/src/Entity/MailRequest.php
@@ -175,6 +175,22 @@ class MailRequest implements MailRequestInterface
     /**
      * {@inheritdoc}
      */
+    public function getSenderName(): ?string
+    {
+        return $this->vars->getSenderName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSenderEmail(): ?string
+    {
+        return $this->vars->getSenderEmail();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getTemplateName(): string
     {
         return $this->vars->getTemplateName();
@@ -188,9 +204,20 @@ class MailRequest implements MailRequestInterface
         return $this->vars->getTemplateVars();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->vars->getCreatedAt();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubject(): ?string
+    {
+        return $this->vars->getSubject();
     }
 
     /**

--- a/src/Entity/MailVars.php
+++ b/src/Entity/MailVars.php
@@ -70,7 +70,7 @@ class MailVars
      * @var Address[]|Collection
      *
      * @ORM\ManyToMany(targetEntity="Address", cascade={"persist", "refresh"})
-     * @ORM\JoinTable(name="mails_cc")
+     * @ORM\JoinTable(name="mailer_mails_cc")
      */
     private $ccRecipients;
 
@@ -78,7 +78,7 @@ class MailVars
      * @var Address[]|Collection
      *
      * @ORM\ManyToMany(targetEntity="Address", cascade={"persist", "refresh"})
-     * @ORM\JoinTable(name="mails_bcc")
+     * @ORM\JoinTable(name="mailer_mails_bcc")
      */
     private $bccRecipients;
 
@@ -97,6 +97,27 @@ class MailVars
     private $createdAt;
 
     /**
+     * @var string|null
+     *
+     * @ORM\Column(nullable=true)
+     */
+    private $senderName;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(nullable=true)
+     */
+    private $senderEmail;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(nullable=true)
+     */
+    private $subject;
+
+    /**
      * @param string[]  $templateVars
      * @param Address[] $ccRecipients
      * @param Address[] $bccRecipients
@@ -106,6 +127,9 @@ class MailVars
         string $type,
         string $templateName,
         Address $replyTo = null,
+        string $senderName = null,
+        string $senderEmail = null,
+        string $subject = null,
         array $templateVars = [],
         array $ccRecipients = [],
         array $bccRecipients = [],
@@ -115,9 +139,14 @@ class MailVars
         $this->app = $app;
         $this->type = $type;
         $this->replyTo = $replyTo;
+        $this->senderName = $senderName;
+        $this->senderEmail = $senderEmail;
+        $this->subject = $subject;
         $this->templateName = $templateName;
         $this->templateVars = $templateVars;
+
         $this->ccRecipients = new ArrayCollection();
+
         foreach ($ccRecipients as $ccRecipient) {
             if (!$ccRecipient instanceof Address) {
                 throw new \InvalidArgumentException(\sprintf(
@@ -128,7 +157,9 @@ class MailVars
             }
             $this->ccRecipients->add($ccRecipient);
         }
+
         $this->bccRecipients = new ArrayCollection();
+
         foreach ($bccRecipients as $bccRecipient) {
             if (!$bccRecipient instanceof Address) {
                 throw new \InvalidArgumentException(\sprintf(
@@ -161,6 +192,21 @@ class MailVars
     public function getReplyTo(): ?Address
     {
         return $this->replyTo;
+    }
+
+    public function getSenderName(): ?string
+    {
+        return $this->senderName;
+    }
+
+    public function getSenderEmail(): ?string
+    {
+        return $this->senderEmail;
+    }
+
+    public function getSubject(): ?string
+    {
+        return $this->subject;
     }
 
     public function getTemplateName(): string

--- a/src/Mail/MailBuilder.php
+++ b/src/Mail/MailBuilder.php
@@ -15,14 +15,16 @@ class MailBuilder extends Mail implements MailBuilderInterface
     private $ccRecipients = [];
     private $bccRecipients = [];
     private $replyTo;
+    private $sender;
     private $templateVars = [];
+    private $subject;
 
     /**
      * {@inheritdoc}
      */
     public function addToRecipient(RecipientInterface $recipient): MailBuilderInterface
     {
-        $this->toRecipients[$recipient->getEmail()] = $recipient;
+        $this->toRecipients[] = $recipient;
 
         return $this;
     }
@@ -30,9 +32,14 @@ class MailBuilder extends Mail implements MailBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function removeToRecipient(RecipientInterface $recipient): MailBuilderInterface
+    public function removeToRecipient(RecipientInterface $recipientToRemove): MailBuilderInterface
     {
-        unset($this->toRecipients[$recipient->getEmail()]);
+        $this->toRecipients = array_filter(
+            $this->toRecipients,
+            function (Recipient $recipient) use ($recipientToRemove) {
+                return $recipient->getEmail() !== $recipientToRemove->getEmail();
+            }
+        );
 
         return $this;
     }
@@ -143,6 +150,16 @@ class MailBuilder extends Mail implements MailBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function setSender(SenderInterface $sender): MailBuilderInterface
+    {
+        $this->sender = $sender;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function addTemplateVar(string $name, string $value): MailBuilderInterface
     {
         $this->templateVars[$name] = $value;
@@ -173,6 +190,16 @@ class MailBuilder extends Mail implements MailBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function setSubject(string $subject): MailBuilderInterface
+    {
+        $this->subject = $subject;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getMail(): MailInterface
     {
         if (!$this->toRecipients) {
@@ -183,9 +210,11 @@ class MailBuilder extends Mail implements MailBuilderInterface
             $this->getApp(),
             $this->resetToRecipients(),
             $this->replyTo,
+            $this->sender,
             $this->ccRecipients,
             $this->bccRecipients,
-            $this->templateVars
+            $this->templateVars,
+            $this->subject
         );
     }
 

--- a/src/Mail/MailBuilderInterface.php
+++ b/src/Mail/MailBuilderInterface.php
@@ -45,6 +45,8 @@ interface MailBuilderInterface extends MailInterface
 
     public function removeTemplateVar(string $name): self;
 
+    public function setSender(SenderInterface $sender): self;
+
     /**
      * @param string[] $templateVars
      */
@@ -62,4 +64,6 @@ interface MailBuilderInterface extends MailInterface
      * @throws InvalidMailClassException
      */
     public static function create(string $mailClass, string $app): self;
+
+    public function setSubject(string $subject): self;
 }

--- a/src/Mail/MailFactory.php
+++ b/src/Mail/MailFactory.php
@@ -38,7 +38,9 @@ class MailFactory implements MailFactoryInterface
         string $mailClass,
         array $to,
         RecipientInterface $replyTo = null,
-        array $templateVars = []
+        array $templateVars = [],
+        string $subject = null,
+        SenderInterface $sender = null
     ): MailInterface {
         $builder = MailBuilder::create($mailClass, $this->app)
             ->setToRecipients($to)
@@ -50,11 +52,17 @@ class MailFactory implements MailFactoryInterface
         if ($templateVars) {
             $builder->setTemplateVars($templateVars);
         }
+        if ($subject) {
+            $builder->setSubject($subject);
+        }
         if ($this->cc) {
             $builder->setCcRecipients($this->cc);
         }
         if ($this->bcc) {
             $builder->setBccRecipients($this->bcc);
+        }
+        if ($sender) {
+            $builder->setSender($sender);
         }
 
         return $builder->getMail();

--- a/src/Mail/MailFactoryInterface.php
+++ b/src/Mail/MailFactoryInterface.php
@@ -18,6 +18,8 @@ interface MailFactoryInterface
         string $mailClass,
         array $to,
         RecipientInterface $replyTo = null,
-        array $templateVars = []
+        array $templateVars = [],
+        string $subject = null,
+        SenderInterface $sender = null
     ): MailInterface;
 }

--- a/src/Mail/MailInterface.php
+++ b/src/Mail/MailInterface.php
@@ -30,6 +30,10 @@ interface MailInterface
 
     public function getReplyTo(): ?RecipientInterface;
 
+    public function getSender(): ?SenderInterface;
+
+    public function getSubject(): ?string;
+
     /**
      * The common vars for campaign emails
      *

--- a/src/Mail/Sender.php
+++ b/src/Mail/Sender.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace EnMarche\MailerBundle\Mail;
+
+class Sender implements SenderInterface
+{
+    private $email;
+    private $name;
+
+    final public function __construct(?string $email, ?string $name)
+    {
+        if (null === $email && null === $name) {
+            throw new \InvalidArgumentException('Email or Name must be filled');
+        }
+
+        $this->email = $email;
+        $this->name = $name;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/src/Mail/SenderInterface.php
+++ b/src/Mail/SenderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EnMarche\MailerBundle\Mail;
+
+interface SenderInterface
+{
+    public function getEmail(): ?string;
+
+    public function getName(): ?string;
+}

--- a/src/MailPost/MailPost.php
+++ b/src/MailPost/MailPost.php
@@ -4,6 +4,7 @@ namespace EnMarche\MailerBundle\MailPost;
 
 use EnMarche\MailerBundle\Mail\MailFactoryInterface;
 use EnMarche\MailerBundle\Mail\RecipientInterface;
+use EnMarche\MailerBundle\Mail\SenderInterface;
 use EnMarche\MailerBundle\Mailer\MailerInterface;
 
 class MailPost implements MailPostInterface
@@ -20,14 +21,22 @@ class MailPost implements MailPostInterface
     /**
      * {@inheritdoc}
      */
-    public function address(string $mailClass, $to, RecipientInterface $replyTo = null, array $templateVars = []): void
-    {
+    public function address(
+        string $mailClass,
+        $to,
+        RecipientInterface $replyTo = null,
+        array $templateVars = [],
+        string $subject = null,
+        SenderInterface $sender = null
+    ): void {
         $to = $to instanceof RecipientInterface ? [$to] : $to;
 
         if (!\is_array($to)) {
             throw new \InvalidArgumentException(\sprintf('Expected an array, got "%s".', \is_object($to) ? \get_class($to) : \gettype($to)));
         }
 
-        $this->mailer->send($this->mailFactory->createForClass($mailClass, $to, $replyTo, $templateVars));
+        $this->mailer->send(
+            $this->mailFactory->createForClass($mailClass, $to, $replyTo, $templateVars, $subject, $sender)
+        );
     }
 }

--- a/src/MailPost/MailPostInterface.php
+++ b/src/MailPost/MailPostInterface.php
@@ -4,6 +4,7 @@ namespace EnMarche\MailerBundle\MailPost;
 
 use EnMarche\MailerBundle\Mail\MailFactoryInterface;
 use EnMarche\MailerBundle\Mail\RecipientInterface;
+use EnMarche\MailerBundle\Mail\SenderInterface;
 
 /**
  * A friendly interface for producer applications.
@@ -15,5 +16,12 @@ interface MailPostInterface
      *
      * @param RecipientInterface|RecipientInterface[] $to One or more recipients
      */
-    public function address(string $mailClass, $to, RecipientInterface $replyTo = null, array $templateVars = []): void;
+    public function address(
+        string $mailClass,
+        $to,
+        RecipientInterface $replyTo = null,
+        array $templateVars = [],
+        string $subject = null,
+        SenderInterface $sender = null
+    ): void;
 }

--- a/src/Repository/AddressRepository.php
+++ b/src/Repository/AddressRepository.php
@@ -5,28 +5,27 @@ namespace EnMarche\MailerBundle\Repository;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
 use EnMarche\MailerBundle\Entity\Address;
-use EnMarche\MailerBundle\Mail\RecipientInterface;
 
 class AddressRepository extends EntityRepository
 {
     /**
      * @throws NonUniqueResultException
      */
-    public function findOneForEmail(string $email): ?Address
+    public function findOneByEmailAndName(string $email, string $name = null): ?Address
     {
-        return $this->createQueryBuilder('address')
+        $qb = $this
+            ->createQueryBuilder('address')
             ->where('address.canonicalEmail = :email')
             ->setParameter('email', Address::canonicalize($email))
-            ->getQuery()
-            ->getOneOrNullResult()
         ;
-    }
 
-    /**
-     * @throws NonUniqueResultException
-     */
-    public function findOneForRecipient(RecipientInterface $recipient)
-    {
-        return $this->findOneForEmail($recipient->getEmail());
+        if ($name) {
+            $qb
+                ->andWhere('address.name = :name')
+                ->setParameter('name', $name)
+            ;
+        }
+
+        return $qb->getQuery()->getOneOrNullResult();
     }
 }

--- a/src/Test/DummyMail.php
+++ b/src/Test/DummyMail.php
@@ -4,6 +4,7 @@ namespace EnMarche\MailerBundle\Test;
 
 use EnMarche\MailerBundle\Mail\MailInterface;
 use EnMarche\MailerBundle\Mail\RecipientInterface;
+use EnMarche\MailerBundle\Mail\SenderInterface;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
@@ -14,6 +15,8 @@ class DummyMail implements MailInterface
     protected $ccRecipients = [];
     protected $bccRecipients = [];
     protected $replyTo;
+    protected $sender;
+    protected $subject;
     protected $templateVars = [];
     protected $templateName = 'dummy';
     protected $type = 'fake';
@@ -71,6 +74,14 @@ class DummyMail implements MailInterface
     public function getReplyTo(): ?RecipientInterface
     {
         return $this->replyTo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSender(): ?SenderInterface
+    {
+        return $this->sender;
     }
 
     /**
@@ -134,5 +145,13 @@ class DummyMail implements MailInterface
     public function serialize(): string
     {
         return \serialize($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubject(): ?string
+    {
+        return $this->subject;
     }
 }

--- a/src/Test/DummyMailRequest.php
+++ b/src/Test/DummyMailRequest.php
@@ -12,6 +12,8 @@ class DummyMailRequest implements MailRequestInterface
     protected $app = 'test';
     protected $type = 'fake';
     protected $replyTo;
+    protected $senderName;
+    protected $senderEmail;
     protected $templateName = 'dummy';
     protected $templateVars = [];
     protected $recipientVars = [];
@@ -22,6 +24,7 @@ class DummyMailRequest implements MailRequestInterface
     protected $deliveredAt;
     protected $requestPayload;
     protected $responsePayload;
+    protected $subject;
 
     public function __construct(\DateTimeImmutable $createdAt = null)
     {
@@ -58,6 +61,22 @@ class DummyMailRequest implements MailRequestInterface
     public function getReplyTo(): ?Address
     {
         return $this->replyTo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSenderName(): ?string
+    {
+        return $this->senderName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSenderEmail(): ?string
+    {
+        return $this->senderEmail;
     }
 
     /**
@@ -124,6 +143,9 @@ class DummyMailRequest implements MailRequestInterface
         return $this->campaign;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->createdAt;
@@ -162,8 +184,19 @@ class DummyMailRequest implements MailRequestInterface
         $this->deliveredAt = $deliveredAt ?: new \DateTimeImmutable();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getDeliveredAt(): ?\DateTimeImmutable
     {
         return $this->deliveredAt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubject(): ?string
+    {
+        return $this->subject;
     }
 }

--- a/src/Test/MailTestCaseTrait.php
+++ b/src/Test/MailTestCaseTrait.php
@@ -2,6 +2,7 @@
 
 namespace EnMarche\MailerBundle\Test;
 
+use EnMarche\MailerBundle\Mail\RecipientInterface;
 use EnMarche\MailerBundle\MailPost\MailPostInterface;
 
 /**
@@ -9,32 +10,34 @@ use EnMarche\MailerBundle\MailPost\MailPostInterface;
  */
 trait MailTestCaseTrait
 {
-    // Should be cleared at tear down if the kernel does not reboot to prevent memory leaks
+    /**
+     * Should be cleared at tear down if the kernel does not reboot to prevent memory leaks
+     *
+     * @var DebugMailPost
+     */
     private $mailPost;
 
     public function getMailPost(string $name = null): DebugMailPost
     {
-        if ($this->mailPost) {
-            return $this->mailPost;
+        if (!$this->mailPost) {
+            $this->mailPost = self::$kernel->getContainer()->get($name ? "en_marche_mailer.mail_post.$name" : MailPostInterface::class);
+
+            if (!$this->mailPost instanceof DebugMailPost) {
+                throw new \LogicException(\sprintf('Expected an instance of "%s", but got "%s". Are you running in test environment? Otherwise you need to explicitly load the bundle config file.', DebugMailPost::class, \get_class($mailPost)));
+            }
         }
 
-        $mailPost = self::$kernel->getContainer()->get($name ? "en_marche_mailer.mail_post.$name" : MailPostInterface::class);
-
-        if (!$mailPost instanceof DebugMailPost) {
-            throw new \LogicException(\sprintf('Expected an instance of "%s", but got "%s". Are you running in test environment? Otherwise you need to explicitly load the bundle config file.', DebugMailPost::class, \get_class($mailPost)));
-        }
-
-        return $mailPost;
+        return $this->mailPost;
     }
 
     public function assertMailCount(int $expectedCount, string $mailPostName = null): void
     {
-        $this->assertCount($expectedCount, $this->getMailPost($mailPostName)->getMailsCount());
+        self::assertCount($expectedCount, $this->getMailPost($mailPostName)->countMails());
     }
 
     public function assertMailCountForClass(int $expectedCount, string $mailClass, string $mailPostName = null): void
     {
-        $this->assertCount($expectedCount, $this->getMailPost($mailPostName)->getMailsCountForClass($mailClass));
+        self::assertSame($expectedCount, $this->getMailPost($mailPostName)->countMailsForClass($mailClass));
     }
 
     public function assertMailSentForRecipient(string $expectedEmail, string $mailClass = null, string $mailPostName = null): void
@@ -53,11 +56,11 @@ trait MailTestCaseTrait
             }
         }
 
-        $this->assertTrue($sent, \sprintf(
+        self::assertTrue($sent, \sprintf(
             'No mail%s was sent for "%s" among %d mail(s).',
             $mailClass ? " ($mailClass)" : '',
             $expectedEmail,
-            $mailClass ? $mailPost->getMailsCountForClass($mailClass) : $mailPost->getMailsCount()
+            $mailClass ? $mailPost->countMailsForClass($mailClass) : $mailPost->countMails()
         ));
     }
 
@@ -84,11 +87,31 @@ trait MailTestCaseTrait
         }
         $expectedEmails = \array_filter($expectedEmails);
 
-        $this->assertCount(0, \sprintf(
+        self::assertCount(0, $expectedEmails, \sprintf(
             'No mail%s was sent for "%s" among %d mail(s).',
             $mailClass ? " ($mailClass)" : '',
             \implode('", "', $expectedEmails),
-            $mailClass ? $mailPost->getMailsCountForClass($mailClass) : $mailPost->getMailsCount()
+            $mailClass ? $mailPost->countMailsForClass($mailClass) : $mailPost->countMails()
         ));
+    }
+
+    public static function assertMessageRecipient(
+        string $expectedEmail,
+        string $expectedName,
+        array $expectedVars,
+        RecipientInterface $recipient
+    ): void {
+        self::assertSame($expectedEmail, $recipient->getEmail());
+        self::assertSame($expectedName, $recipient->getName());
+        self::assertSame($expectedVars, $recipient->getTemplateVars());
+    }
+
+    protected function clearMails(string $mailPostName = null): void
+    {
+        if (!$this->mailPost) {
+            $this->mailPost = $this->getMailPost($mailPostName);
+        }
+
+        $this->mailPost->clearMails();
     }
 }

--- a/tests/Client/MailRequestFactoryTest.php
+++ b/tests/Client/MailRequestFactoryTest.php
@@ -65,7 +65,7 @@ class MailRequestFactoryTest extends TestCase
             ->method('findOneForCampaign')
         ;
         $this->addressRepository->expects($this->exactly(4))
-            ->method('findOneForRecipient')
+            ->method('findOneByEmailAndName')
             ->willReturnOnConsecutiveCalls(null, null, null, null)
         ;
 
@@ -115,6 +115,9 @@ class MailRequestFactoryTest extends TestCase
             $mail->getType(),
             $mail->getTemplateName(),
             null,
+            'Sender Name',
+            'sender@email.com',
+            null,
             $mail->getTemplateVars(),
             [new Address(...$cc)],
             [],
@@ -126,7 +129,7 @@ class MailRequestFactoryTest extends TestCase
             ->willReturn($mailVars)
         ;
         $this->addressRepository->expects($this->exactly(2))
-            ->method('findOneForRecipient')
+            ->method('findOneByEmailAndName')
         ;
 
         $mailRequest = $this->mailRequestFactory->createRequestForMail($mail);

--- a/tests/Client/PayloadFactory/MailjetPayloadFactoryTest.php
+++ b/tests/Client/PayloadFactory/MailjetPayloadFactoryTest.php
@@ -94,7 +94,6 @@ class MailjetPayloadFactoryTest extends TestCase
         $recipient1Email = 'recipient_1_email';
         $recipient1Vars = ['recipient_var' => 'test_1'];
         $recipient2Email = 'recipient_2_email';
-        $recipient2Vars = ['recipient_var' => 'test_2'];
         $replyToEmail = 'reply_to_email';
         $templateVars = ['template_var' => 'test_a', 'recipient_var' => 'default must be overridden'];
 
@@ -102,15 +101,15 @@ class MailjetPayloadFactoryTest extends TestCase
             'MJ-TemplateID' => 'dummy',
             'MJ-TemplateLanguage' => true,
             'Headers' => ['Reply-To' => \sprintf('<%s>', $replyToEmail)],
+            'Vars' => $templateVars,
             'Recipients' => [
                 [
                     'Email' => $recipient1Email,
                     'Name' => $recipient1Name,
-                    'Vars' => \array_merge($templateVars, $recipient1Vars),
+                    'Vars' => $recipient1Vars,
                 ],
                 [
                     'Email' => $recipient2Email,
-                    'Vars' => \array_merge($templateVars, $recipient2Vars),
                 ],
             ],
         ];
@@ -118,7 +117,7 @@ class MailjetPayloadFactoryTest extends TestCase
         $mailRequest = $this->getMailRequest(
             [
                 $this->getRecipientVars($recipient1Email, $recipient1Name, $recipient1Vars),
-                $this->getRecipientVars($recipient2Email, null, $recipient2Vars),
+                $this->getRecipientVars($recipient2Email),
             ],
             [/* no cc */],
             [/* no bcc */],

--- a/tests/Mail/MailFactoryTest.php
+++ b/tests/Mail/MailFactoryTest.php
@@ -29,28 +29,25 @@ class MailFactoryTest extends TestCase
     {
         yield [
             TotoMail::class,
-            [
-                'email' => $this->getRecipient('email'),
-            ],
+            [$this->getRecipient('email')],
             null, // no reply to
             [], // no template vars
         ];
         yield [
             HeahMail::class,
-            [
-                'email' => $this->getRecipient('email'),
-            ],
+            [$this->getRecipient('email')],
             $this->getRecipient('reply_to_email'),
             ['var' => 'test'],
+            'Beautiful email subject',
         ];
     }
 
     /**
      * @dataProvider provideMailData
      */
-    public function testCreateForClass(string $mailClass, array $to, ?RecipientInterface $replyTo, array $templateVars)
+    public function testCreateForClass(string $mailClass, array $to, ?RecipientInterface $replyTo, array $templateVars, string $subject = null)
     {
-        $mail = $this->mailFactory->createForClass($mailClass, $to, $replyTo, $templateVars);
+        $mail = $this->mailFactory->createForClass($mailClass, $to, $replyTo, $templateVars, $subject);
 
         $this->assertInstanceOf($mailClass, $mail);
         $this->assertSame('test', $mail->getApp());
@@ -59,6 +56,7 @@ class MailFactoryTest extends TestCase
         $this->assertSame($templateVars, $mail->getTemplateVars());
         $this->assertSame([], $mail->getCcRecipients());
         $this->assertSame([], $mail->getBccRecipients());
+        $this->assertSame($subject, $mail->getSubject());
     }
 
     /**

--- a/tests/Mail/MailTest.php
+++ b/tests/Mail/MailTest.php
@@ -12,14 +12,14 @@ class MailTest extends TestCase
 {
     public function provideTemplateNamesForMailClasses(): iterable
     {
-        yield FooMail::class => [FooMail::class, 'foo'];
-        yield FooBarMail::class => [FooBarMail::class, 'foo_bar'];
-        yield FooBarBaz::class => [FooBarBaz::class, 'foo_bar_baz'];
-        yield FooBarMailBaz::class => [FooBarMailBaz::class, 'foo_bar_mail_baz'];
-        yield BAZMail::class => [BAZMail::class, 'baz'];
-        yield HTMLStuffMail::class => [HTMLStuffMail::class, 'html_stuff'];
-        yield FixHTMLStuffMail::class => [FixHTMLStuffMail::class, 'fix_html_stuff'];
-        yield Foo1Mail::class => [Foo1Mail::class, 'foo1'];
+        yield FooMail::class => [FooMail::class, 'test_foo'];
+        yield FooBarMail::class => [FooBarMail::class, 'test_foo_bar'];
+        yield FooBarBaz::class => [FooBarBaz::class, 'test_foo_bar_baz'];
+        yield FooBarMailBaz::class => [FooBarMailBaz::class, 'test_foo_bar_mail_baz'];
+        yield BAZMail::class => [BAZMail::class, 'test_baz'];
+        yield HTMLStuffMail::class => [HTMLStuffMail::class, 'test_html_stuff'];
+        yield FixHTMLStuffMail::class => [FixHTMLStuffMail::class, 'test_fix_html_stuff'];
+        yield Foo1Mail::class => [Foo1Mail::class, 'test_foo1'];
     }
 
     /**


### PR DESCRIPTION
Add:
 - `SenderInterface` and `Sender` class with two properties: email, name
 - Add optionals arguments to `MailPost::address()` method: `SenderInterface` and string subject to allow config them for one mail
